### PR TITLE
fixing theme for 'Next' button in tasks

### DIFF
--- a/lib/src/ui/RPUITask.dart
+++ b/lib/src/ui/RPUITask.dart
@@ -346,6 +346,7 @@ class RPUITaskState extends State<RPUITask> with CanSaveResult {
                                     }
                                   : null,
                               child: Text(
+                                style: const TextStyle(color: Colors.white),
                                 RPLocalizations.of(context)
                                         ?.translate('NEXT') ??
                                     "NEXT",


### PR DESCRIPTION
Closes https://github.com/cph-cachet/carp-studies-app/issues/183

The text on the 'Next' button disappeared when user selected one of the options 