### PR TITLE
Fix issue #97

### DIFF
--- a/lib/src/ui/QuestionBody/RPUIDoubleQuestionBody.dart
+++ b/lib/src/ui/QuestionBody/RPUIDoubleQuestionBody.dart
@@ -78,7 +78,7 @@ class RPUIDoubleQuestionBodyState extends State<RPUIDoubleQuestionBody>
           errorText: _valid ? null : _errorMessage,
         ),
         onChanged: (text) => _validate(text, locale),
-        keyboardType: TextInputType.number,
+        keyboardType: TextInputType.numberWithOptions(decimal: true),
       ),
     );
   }


### PR DESCRIPTION
Fixed an issue in which the double-type question would not allow a dot or comma to be inserted while on iOS.