### PR TITLE
Make informed consent detail view scrollable when text overflows

### DIFF
--- a/lib/src/ui/RPUIInstructionStep.dart
+++ b/lib/src/ui/RPUIInstructionStep.dart
@@ -127,13 +127,17 @@ class _DetailTextRoute extends StatelessWidget {
                     style: Theme.of(context).textTheme.headlineSmall),
               ],
             ),
-            Container(
-              padding: const EdgeInsets.all(20.0),
-              child: SingleChildScrollView(
-                child: Text(
-                  locale?.translate(content) ?? content,
-                  style: Theme.of(context).textTheme.bodyLarge,
-                  textAlign: TextAlign.start,
+            Expanded(
+              child: Scrollbar(
+                child: SingleChildScrollView(
+                  child: Container(
+                    padding: EdgeInsets.all(20.0),
+                    child: Text(
+                      locale?.translate(content) ?? content,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                      textAlign: TextAlign.start,
+                    ),
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
Long text now correctly overflows and shows a scrollbar if needed.

![image](https://github.com/cph-cachet/research.package/assets/10660846/656c4c2b-c458-4bc6-b7fa-e73c9e9d9518)

Closes #100 