### PR TITLE
Remove `simple_html_css` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1
+
+* Fix issue [#115](https://github.com/cph-cachet/research.package/issues/115) by removing unused widgets, `simple_html_css` package
+
 ## 1.5.0
 
 * fix of issue [#111](https://github.com/cph-cachet/research.package/issues/111)

--- a/lib/src/ui/instruction_step.dart
+++ b/lib/src/ui/instruction_step.dart
@@ -166,22 +166,3 @@ class InstructionImage extends StatelessWidget {
     );
   }
 }
-
-// Render the title above the questionBody
-class InstructionText extends StatelessWidget {
-  final String text;
-  const InstructionText(this.text, {super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    if (text.contains('</')) {
-      return HTML.toRichText(context, text);
-    } else {
-      return Text(
-        text,
-        style: Theme.of(context).textTheme.bodyLarge,
-        textAlign: TextAlign.start,
-      );
-    }
-  }
-}

--- a/lib/src/ui/question_step.dart
+++ b/lib/src/ui/question_step.dart
@@ -171,25 +171,3 @@ class RPUIQuestionStepState extends State<RPUIQuestionStep> with CanSaveResult {
     }
   }
 }
-
-// Render the title above the questionBody
-class Title extends StatelessWidget {
-  final String title;
-  const Title(this.title, {super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    if (title.contains('</')) {
-      return HTML.toRichText(context, title);
-    } else {
-      return Padding(
-        padding: const EdgeInsets.only(bottom: 24, left: 8, right: 8, top: 8),
-        child: Text(
-          title,
-          style: Theme.of(context).textTheme.titleLarge,
-          textAlign: TextAlign.start,
-        ),
-      );
-    }
-  }
-}

--- a/lib/ui.dart
+++ b/lib/ui.dart
@@ -17,7 +17,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:signature/signature.dart';
-import 'package:simple_html_css/simple_html_css.dart';
 
 import 'model.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   signature: ^5.4.0
   rxdart: ^0.27.7
   json_annotation: ^4.8.0
-  simple_html_css: ^4.0.0
   just_audio: ^0.9.0
 
 # Overriding carp core libraries to use the local copy

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: research_package
 description: A Flutter framework for obtaining informed consent, showing surveys and collecting results.
-version: 1.5.0
+version: 1.5.1
 homepage: https://github.com/cph-cachet/research.package
 
 environment:


### PR DESCRIPTION
The `simple_html_css` package caused build issues when using Flutter 3.22 because the Flutter team renamed some  text styling properties the package used. Although this issue has been fixed in v5.0.0 of the package, it seems that the code that required `simple_html_css` is not called anywhere, so this package can be removed.

The alternative is upgrading the `simple_html_css` to 5.0.0, but then we need to make the research package use Flutter 3.22 as a minimum as well as any project that depends on it.

Closes #115 