### PR TITLE
Migrate to carp_themes_package 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.4.1
+
+* Migrated to `carp_themes_package` 0.2.0: widgets now read colors and text
+  styles from the standard `ThemeData` (`ColorScheme`, `TextTheme`,
+  `scaffoldBackgroundColor`) instead of the removed `CarpColors` extension and
+  `fsXX` text constants.
+* Lowered the minimum Dart SDK to `3.12.0`.
+
 ## 2.4.0
 
 Update dependencies:

--- a/example/lib/linear_survey_page.dart
+++ b/example/lib/linear_survey_page.dart
@@ -35,8 +35,7 @@ class LinearSurveyPage extends StatelessWidget {
         fit: BoxFit.contain,
         height: 16,
       ),
-      carouselBarBackgroundColor:
-          Theme.of(context).extension<CarpColors>()!.backgroundGray,
+      carouselBarBackgroundColor: Theme.of(context).scaffoldBackgroundColor,
       // onCancel: (RPTaskResult? result) {
       //   if (result == null) {
       //     print("No result");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -76,7 +76,6 @@ class RPDemoApp extends StatelessWidget {
         return supportedLocales.first;
       },
       theme: carpTheme,
-      darkTheme: carpDarkTheme,
       title: 'Research Package Demo',
       home: const HomePage(),
       debugShowCheckedModeBanner: false,

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A demo application for Research Package
 publish_to: none
 
 environment:
-  sdk: ^3.12.2
+  sdk: ">=3.12.0 <4.0.0"
   flutter: ">=3.16.0"
 
 dependencies:
@@ -14,6 +14,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
+  carp_themes_package: ^0.2.0
   research_package:
     path: ../
   # carp_serializable:

--- a/lib/src/ui/completion_step.dart
+++ b/lib/src/ui/completion_step.dart
@@ -35,7 +35,7 @@ class RPUICompletionStepState extends State<RPUICompletionStep>
     RPLocalizations? locale = RPLocalizations.of(context);
     return Scaffold(
       backgroundColor:
-          Theme.of(context).extension<CarpColors>()!.backgroundGray,
+          Theme.of(context).scaffoldBackgroundColor,
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -69,7 +69,7 @@ class RPUICompletionStepState extends State<RPUICompletionStep>
               ),
             ),
             ButtonTheme(
-              buttonColor: Theme.of(context).extension<CarpColors>()!.primary,
+              buttonColor: Theme.of(context).colorScheme.primary,
               minWidth: 150,
               child: OutlinedButton(
                 onPressed: () {

--- a/lib/src/ui/consent_review_step.dart
+++ b/lib/src/ui/consent_review_step.dart
@@ -210,7 +210,7 @@ class __TextPresenterRouteState extends State<_TextPresenterRoute> {
                   widget.step.consentDocument.sections[index].summary) ??
               widget.step.consentDocument.sections[index].summary,
           style: Theme.of(context).textTheme.bodyLarge,
-          textAlign: TextAlign.start,
+          textAlign: TextAlign.justify,
         ),
         widget.step.consentDocument.sections[index].content != null
             ? Text(
@@ -218,7 +218,7 @@ class __TextPresenterRouteState extends State<_TextPresenterRoute> {
                         widget.step.consentDocument.sections[index].content!) ??
                     widget.step.consentDocument.sections[index].content!,
                 style: Theme.of(context).textTheme.bodyLarge,
-                textAlign: TextAlign.start,
+                textAlign: TextAlign.justify,
               )
             : Container(),
       ],
@@ -245,14 +245,9 @@ class __TextPresenterRouteState extends State<_TextPresenterRoute> {
                   style: TextStyle(color: Theme.of(context).primaryColor),
                 ),
               ),
-              TextButton(
-                style: ButtonStyle(
-                  backgroundColor: WidgetStateProperty.all(
-                      Theme.of(context).colorScheme.primary),
-                ),
+              FilledButton(
                 onPressed: onPressedCallback,
-                child: Text(locale?.translate('AGREE') ?? "AGREE",
-                    style: Theme.of(context).textTheme.labelLarge),
+                child: Text(locale?.translate('AGREE') ?? "AGREE"),
               ),
             ],
           );
@@ -280,15 +275,8 @@ class __TextPresenterRouteState extends State<_TextPresenterRoute> {
             blocTask.sendStatus(RPStepStatus.Canceled);
           },
         ),
-        TextButton(
-          style: ButtonStyle(
-            backgroundColor:
-                WidgetStateProperty.all(Theme.of(context).primaryColor),
-          ),
-          child: Text(
-            locale?.translate('AGREE') ?? "AGREE",
-            style: Theme.of(context).textTheme.labelLarge,
-          ),
+        FilledButton(
+          child: Text(locale?.translate('AGREE') ?? "AGREE"),
           onPressed: () {
             showConsentDialog(
               widget.step.consentDocument.signatures.isNotEmpty
@@ -465,8 +453,6 @@ class _SignatureRouteState extends State<_SignatureRoute> {
         ),
         persistentFooterButtons: <Widget>[
           ElevatedButton(
-            style: ElevatedButton.styleFrom(
-                backgroundColor: Theme.of(context).primaryColor),
             onPressed: (_isNameFilled && _isSignatureAdded)
                 ? () {
                     if (widget._consentSignature.requiresSignatureImage) {
@@ -495,10 +481,7 @@ class _SignatureRouteState extends State<_SignatureRoute> {
                     blocTask.sendStatus(RPStepStatus.Finished);
                   }
                 : null,
-            child: Text(
-              locale?.translate('NEXT') ?? "NEXT",
-              style: Theme.of(context).primaryTextTheme.labelLarge,
-            ),
+            child: Text(locale?.translate('NEXT') ?? "NEXT"),
           ),
           //),
         ],

--- a/lib/src/ui/consent_review_step.dart
+++ b/lib/src/ui/consent_review_step.dart
@@ -248,7 +248,7 @@ class __TextPresenterRouteState extends State<_TextPresenterRoute> {
               TextButton(
                 style: ButtonStyle(
                   backgroundColor: WidgetStateProperty.all(
-                      Theme.of(context).extension<CarpColors>()!.primary),
+                      Theme.of(context).colorScheme.primary),
                 ),
                 onPressed: onPressedCallback,
                 child: Text(locale?.translate('AGREE') ?? "AGREE",
@@ -262,7 +262,7 @@ class __TextPresenterRouteState extends State<_TextPresenterRoute> {
 
     return Scaffold(
       backgroundColor:
-          Theme.of(context).extension<CarpColors>()!.backgroundGray,
+          Theme.of(context).scaffoldBackgroundColor,
       body: SafeArea(
         child: ListView.builder(
           padding: const EdgeInsets.all(16),
@@ -448,7 +448,7 @@ class _SignatureRouteState extends State<_SignatureRoute> {
       onPanDown: (_) => FocusScope.of(context).unfocus(),
       child: Scaffold(
         backgroundColor:
-            Theme.of(context).extension<CarpColors>()!.backgroundGray,
+            Theme.of(context).scaffoldBackgroundColor,
         body: SafeArea(
           child: ListView(
             padding: const EdgeInsets.all(12),

--- a/lib/src/ui/instruction_step.dart
+++ b/lib/src/ui/instruction_step.dart
@@ -64,7 +64,7 @@ class RPUIInstructionStepState extends State<RPUIInstructionStep> {
     RPLocalizations? locale = RPLocalizations.of(context);
     return Scaffold(
       backgroundColor:
-          Theme.of(context).extension<CarpColors>()!.backgroundGray,
+          Theme.of(context).scaffoldBackgroundColor,
       body: SafeArea(
         child: Column(
           children: <Widget>[

--- a/lib/src/ui/questions/choice_question_body.dart
+++ b/lib/src/ui/questions/choice_question_body.dart
@@ -69,7 +69,6 @@ class RPUIChoiceQuestionBodyState extends State<RPUIChoiceQuestionBody>
           : false,
       currentChoices: selectedChoices,
       index: index,
-      isLastChoice: index == widget.answerFormat.choices.length - 1,
       answerStyle: widget.answerFormat.answerStyle,
     );
   }
@@ -88,10 +87,17 @@ class RPUIChoiceQuestionBodyState extends State<RPUIChoiceQuestionBody>
                     RPChoiceAnswerStyle.MultipleChoice)
                 ? "(${locale?.translate('choose_one_or_more_options') ?? 'Choose one or more options'})"
                 : "(${locale?.translate('choose_one_option') ?? 'Choose one option'})")),
-        ListView.builder(
+        ListView.separated(
           shrinkWrap: true,
           itemCount: widget.answerFormat.choices.length,
           itemBuilder: _choiceCellBuilder,
+          separatorBuilder: (context, index) => Divider(
+            height: 1,
+            thickness: 1,
+            indent: 16,
+            endIndent: 16,
+            color: Colors.grey.shade300,
+          ),
           physics: const NeverScrollableScrollPhysics(),
         ),
       ],
@@ -107,7 +113,6 @@ class _ChoiceButton extends StatefulWidget {
   final Function selectedCallBack;
   final List<RPChoice> currentChoices;
   final bool selected;
-  final bool isLastChoice;
   final int index;
   final RPChoiceAnswerStyle answerStyle;
 
@@ -117,8 +122,7 @@ class _ChoiceButton extends StatefulWidget {
       required this.currentChoices,
       required this.index,
       required this.answerStyle,
-      required this.selected,
-      required this.isLastChoice});
+      required this.selected});
 
   @override
   _ChoiceButtonState createState() => _ChoiceButtonState();
@@ -168,14 +172,6 @@ class _ChoiceButtonState extends State<_ChoiceButton> {
               padding: widget.choice.isFreeText
                   ? null
                   : const EdgeInsets.only(bottom: 13),
-              decoration: !widget.isLastChoice
-                  ? BoxDecoration(
-                      border: Border(
-                        bottom:
-                            BorderSide(color: Theme.of(context).dividerColor),
-                      ),
-                    )
-                  : null,
               child: widget.choice.isFreeText
                   ? TextField(
                       onChanged: (newText) => widget.choice.text = newText,

--- a/lib/src/ui/task.dart
+++ b/lib/src/ui/task.dart
@@ -282,7 +282,10 @@ class RPUITaskState extends State<RPUITask> with CanSaveResult {
                       '${_currentStepIndex + 1} '
                       '${locale?.translate('of') ?? 'of'} '
                       '${widget.task.steps.length}',
-                      style: Theme.of(context).appBarTheme.titleTextStyle,
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyLarge
+                          ?.copyWith(fontSize: 18),
                       textAlign: TextAlign.center,
                     )
                   : Container(),

--- a/lib/src/ui/task.dart
+++ b/lib/src/ui/task.dart
@@ -258,7 +258,7 @@ class RPUITaskState extends State<RPUITask> with CanSaveResult {
         vertical: widget.carouselBarVerticalPadding ?? 0,
       ),
       color: widget.carouselBarBackgroundColor ??
-          Theme.of(context).extension<CarpColors>()!.backgroundGray,
+          Theme.of(context).scaffoldBackgroundColor,
       child: SizedBox(
         height: AppBar().preferredSize.height,
         child: Row(
@@ -321,7 +321,7 @@ class RPUITaskState extends State<RPUITask> with CanSaveResult {
       // },
       child: Scaffold(
         backgroundColor:
-            Theme.of(context).extension<CarpColors>()!.backgroundGray,
+            Theme.of(context).scaffoldBackgroundColor,
         resizeToAvoidBottomInset: true,
         body: SafeArea(
           child: Column(
@@ -374,9 +374,7 @@ class RPUITaskState extends State<RPUITask> with CanSaveResult {
                           if (snapshot.hasData) {
                             return ElevatedButton(
                               style: ElevatedButton.styleFrom(
-                                  backgroundColor: Theme.of(context)
-                                      .extension<CarpColors>()!
-                                      .primary),
+                                  backgroundColor: Theme.of(context).colorScheme.primary),
                               onPressed: snapshot.data!
                                   ? () {
                                       FocusManager.instance.primaryFocus

--- a/lib/src/ui/visual_consent_step.dart
+++ b/lib/src/ui/visual_consent_step.dart
@@ -64,7 +64,7 @@ class RPUIVisualConsentStepState extends State<RPUIVisualConsentStep>
             ElevatedButton(
               style: ElevatedButton.styleFrom(
                   backgroundColor:
-                      Theme.of(context).extension<CarpColors>()!.primary),
+                      Theme.of(context).colorScheme.primary),
               child: Text(
                 RPLocalizations.of(context)?.translate('YES') ?? 'YES',
                 style: Theme.of(context).primaryTextTheme.labelLarge,
@@ -236,8 +236,8 @@ class RPUIVisualConsentStepState extends State<RPUIVisualConsentStep>
               padding: const EdgeInsets.symmetric(vertical: 20),
               child: Text(
                 locale?.translate(section.title) ?? section.title,
-                style: fs24fw700ls0.copyWith(
-                  color: Theme.of(context).extension<CarpColors>()!.primary,
+                style: Theme.of(context).textTheme.headlineSmall!.copyWith(
+                  color: Theme.of(context).colorScheme.primary,
                 ),
                 textAlign: TextAlign.start,
               ),
@@ -281,16 +281,16 @@ class RPUIVisualConsentStepState extends State<RPUIVisualConsentStep>
               children: <Widget>[
                 Text(
                   locale?.translate(section.title) ?? section.title,
-                  style: fs24fw700ls0.copyWith(
-                    color: Theme.of(context).extension<CarpColors>()!.primary,
+                  style: Theme.of(context).textTheme.headlineSmall!.copyWith(
+                    color: Theme.of(context).colorScheme.primary,
                   ),
                   textAlign: TextAlign.start,
                 ),
                 const SizedBox(height: 5),
                 Text(
                   locale?.translate(section.summary) ?? section.summary,
-                  style: fs16fw400ls0.copyWith(
-                    color: Theme.of(context).extension<CarpColors>()!.grey900,
+                  style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                    color: Colors.grey.shade900,
                   ),
                 ),
                 const SizedBox(height: 30),
@@ -304,7 +304,7 @@ class RPUIVisualConsentStepState extends State<RPUIVisualConsentStep>
                         "Learn more",
                     style: Theme.of(context).textTheme.titleLarge!.copyWith(
                         color:
-                            Theme.of(context).extension<CarpColors>()!.primary),
+                            Theme.of(context).colorScheme.primary),
                   ),
                 ),
               ],
@@ -328,8 +328,8 @@ class RPUIVisualConsentStepState extends State<RPUIVisualConsentStep>
               height: 4, // Thickness of the indicator
               decoration: BoxDecoration(
                 color: index < _pageNr
-                    ? Theme.of(context).extension<CarpColors>()!.primary
-                    : Theme.of(context).extension<CarpColors>()!.grey300,
+                    ? Theme.of(context).colorScheme.primary
+                    : Colors.grey.shade300,
                 borderRadius: BorderRadius.circular(4),
               ),
             ),
@@ -356,7 +356,7 @@ class RPUIVisualConsentStepState extends State<RPUIVisualConsentStep>
           TextButton(
             style: ButtonStyle(
               backgroundColor: WidgetStateProperty.all(
-                  Theme.of(context).extension<CarpColors>()!.primary),
+                  Theme.of(context).colorScheme.primary),
             ),
             onPressed: _lastPage
                 ? () => blocTask.sendStatus(RPStepStatus.Finished)
@@ -389,7 +389,7 @@ class RPUIVisualConsentStepState extends State<RPUIVisualConsentStep>
       canPop: false,
       child: Scaffold(
         backgroundColor:
-            Theme.of(context).extension<CarpColors>()!.backgroundGray,
+            Theme.of(context).scaffoldBackgroundColor,
         body: SafeArea(
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -433,8 +433,8 @@ class DataCollectionListItemState extends State<DataCollectionListItem> {
       title: Text(
         locale?.translate(widget.dataTypeSection.dataName) ??
             widget.dataTypeSection.dataName,
-        style: fs20fw700ls0.copyWith(
-          color: Theme.of(context).extension<CarpColors>()!.grey900,
+        style: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20).copyWith(
+          color: Colors.grey.shade900,
         ),
         textAlign: TextAlign.start,
       ),

--- a/lib/src/ui/visual_consent_step.dart
+++ b/lib/src/ui/visual_consent_step.dart
@@ -62,13 +62,7 @@ class RPUIVisualConsentStepState extends State<RPUIVisualConsentStep>
               onPressed: () => Navigator.of(context).pop(), // Pop the popup,
             ),
             ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                  backgroundColor:
-                      Theme.of(context).colorScheme.primary),
-              child: Text(
-                RPLocalizations.of(context)?.translate('YES') ?? 'YES',
-                style: Theme.of(context).primaryTextTheme.labelLarge,
-              ),
+              child: Text(RPLocalizations.of(context)?.translate('YES') ?? 'YES'),
               onPressed: () {
                 Navigator.of(context).pop(); // Pop the popup
                 Navigator.of(context).pop(); // Pop the screen
@@ -353,28 +347,16 @@ class RPUIVisualConsentStepState extends State<RPUIVisualConsentStep>
             ),
             onPressed: () => _showCancelDialog(),
           ),
-          TextButton(
-            style: ButtonStyle(
-              backgroundColor: WidgetStateProperty.all(
-                  Theme.of(context).colorScheme.primary),
-            ),
+          FilledButton(
             onPressed: _lastPage
                 ? () => blocTask.sendStatus(RPStepStatus.Finished)
                 : () => controller.nextPage(
                     duration: const Duration(milliseconds: 400),
                     curve: Curves.fastOutSlowIn),
             child: _lastPage
-                ? Text(
-                    RPLocalizations.of(context)?.translate('SEE_SUMMARY') ??
-                        "SEE SUMMARY",
-                    style: const TextStyle(color: Colors.white),
-                  )
-                : Text(
-                    RPLocalizations.of(context)?.translate('NEXT') ?? "NEXT",
-                    style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                          color: Theme.of(context).colorScheme.onPrimary,
-                        ),
-                  ),
+                ? Text(RPLocalizations.of(context)?.translate('SEE_SUMMARY') ??
+                    "SEE SUMMARY")
+                : Text(RPLocalizations.of(context)?.translate('NEXT') ?? "NEXT"),
           ),
         ],
       ),
@@ -429,6 +411,8 @@ class DataCollectionListItemState extends State<DataCollectionListItem> {
     RPLocalizations? locale = RPLocalizations.of(context);
     return ExpansionTile(
       tilePadding: const EdgeInsets.only(left: 0),
+      shape: const Border(),
+      collapsedShape: const Border(),
       expandedAlignment: Alignment.centerLeft,
       title: Text(
         locale?.translate(widget.dataTypeSection.dataName) ??

--- a/lib/ui.dart
+++ b/lib/ui.dart
@@ -18,7 +18,6 @@ import 'package:flutter/services.dart';
 import 'package:signature/signature.dart';
 import 'package:audioplayers/audioplayers.dart';
 import 'package:video_player/video_player.dart';
-import 'package:carp_themes_package/carp_themes_package.dart';
 
 import 'model.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,17 @@
 name: research_package
 description: A Flutter framework for obtaining informed consent, showing surveys and collecting results.
-version: 2.4.0
+version: 2.4.1
 homepage: https://github.com/cph-cachet/research.package
 
 environment:
-  sdk: ^3.12.2
+  sdk: ">=3.12.0 <4.0.0"
   flutter: ">=3.16.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
-  carp_themes_package: ^0.0.5
+  carp_themes_package: ^0.2.0
   carp_serializable: ^2.0.1
 
   signature: ^6.3.0


### PR DESCRIPTION
Migrates the UI to `carp_themes_package` 0.2.0.

## Migration
- Replace the removed `CarpColors` extension and `fsXX` text constants with standard `ThemeData` (`ColorScheme`, `TextTheme`, `scaffoldBackgroundColor`).
- Bump `carp_themes_package` `^0.0.5` → `^0.2.0`, version `2.4.0` → `2.4.1`, lower min Dart SDK to `3.12.0`.

## Consent screen fixes for the new theme
- Use the themed `FilledButton`/`ElevatedButton` for primary CTAs (AGREE, YES, NEXT, SEE SUMMARY) instead of hand-set background + text colors — fixes black text on primary buttons.
- Enlarge the "X of Y" step counter and make it non-bold.
- Justify the consent review summary/content body text.
- Remove the `ExpansionTile` top/bottom dividers on data-collection dropdowns.
- Lighten/normalize the choice-question option divider.

`flutter analyze` clean (only pre-existing info lints).